### PR TITLE
Add fish shell and aliases

### DIFF
--- a/modules/core/user.nix
+++ b/modules/core/user.nix
@@ -36,7 +36,7 @@ in {
       "scanner"
       "wheel"
     ];
-    shell = pkgs.zsh;
+    shell = pkgs.fish;
     ignoreShellProgramCheck = true;
   };
   nix.settings.allowed-users = ["${username}"];

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -5,6 +5,8 @@ in {
     ./amfora.nix
     ./bash.nix
     ./bashrc-personal.nix
+    ./fish.nix
+    ./fishrc-personal.nix
     ./bat.nix
     ./btop.nix
     ./cava.nix

--- a/modules/home/fish.nix
+++ b/modules/home/fish.nix
@@ -1,0 +1,25 @@
+{profile, ...}: {
+  programs.fish = {
+    enable = true;
+    interactiveShellInit = ''
+      if test -f $HOME/.fishrc-personal
+        source $HOME/.fishrc-personal
+      end
+    '';
+    shellAliases = {
+      sv = "sudo nvim";
+      v = "nvim";
+      c = "clear";
+      fr = "nh os switch --hostname ${profile}";
+      fu = "nh os switch --hostname ${profile} --update";
+      zu = "sh <(curl -L https://gitlab.com/Zaney/zaneyos/-/releases/latest/download/install-zaneyos.sh)";
+      ncg = "nix-collect-garbage --delete-old && sudo nix-collect-garbage -d && sudo /run/current-system/bin/switch-to-configuration boot";
+      cat = "bat";
+      man = "batman";
+      ls = "eza --icons --group-directories-first -1";
+      ll = "eza --icons -lh --group-directories-first -1 --no-user --long";
+      la = "eza --icons -lah --group-directories-first -1";
+      tree = "eza --icons --tree --group-directories-first";
+    };
+  };
+}

--- a/modules/home/fishrc-personal.nix
+++ b/modules/home/fishrc-personal.nix
@@ -1,0 +1,18 @@
+{pkgs, ...}: {
+  home.packages = with pkgs; [ fish ];
+
+  home.file."./.fishrc-personal".text = ''
+
+  # This file allows you to define your own aliases, functions, etc
+  # below are just some examples of what you can use this file for
+
+    #!/usr/bin/env fish
+    # Set defaults
+    #
+    #set -gx EDITOR "nvim"
+    #set -gx VISUAL "nvim"
+
+    #alias c "clear"
+
+  '';
+}


### PR DESCRIPTION
## Summary
- configure fish shell with the same aliases used for zsh
- install a personal fishrc template
- include fish modules in the home environment
- set the default user shell to fish

## Testing
- `nix flake check` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683ec14ea650832cb950e44f5af3010d